### PR TITLE
Fix items overlapping each other

### DIFF
--- a/src/angular-masonry.js
+++ b/src/angular-masonry.js
@@ -44,7 +44,7 @@
             $element.masonry.apply($element, args);
           });
           schedule = [];
-        }, 30);
+        }, 100);
       };
 
       function defaultLoaded($element) {


### PR DESCRIPTION
After getting strange behaviour of sometimes items overlapping each other (i have imagesloaded), i've increased the timeout and that fixed the issue.
I'm not sure if that's the best solution, maybe there is better solution then $timeout all together..
