### PR TITLE
Added an option to remove imagesLoaded dependency

### DIFF
--- a/angular-masonry.js
+++ b/angular-masonry.js
@@ -53,7 +53,11 @@
             self.scheduleMasonryOnce('layout');
           }
         }
-        element.imagesLoaded(_append);
+        if($element.data('masonry-options') == undefined){
+          element.imagesLoaded(_append);
+        }else{
+          _append();
+        }
       };
       this.removeBrick = function removeBrick(id, element) {
         if (destroyed) {
@@ -87,6 +91,7 @@
               itemSelector: attrs.itemSelector || '.masonry-brick',
               columnWidth: parseInt(attrs.columnWidth, 10)
             });
+          element.data('masonry-options', options);
           element.masonry(options);
           scope.$emit('masonry.created', element);
           scope.$on('$destroy', ctrl.destroy);


### PR DESCRIPTION
I had a special use case where I already know the ratio of my image and I didn't wanted to wait the imagesLoaded thing. In order to make something that doesn't break the plugin I added an option "images:false" that will start _append method without waiting the image loading.

I did that pull request from github so I didn't created the minified version the js
