### PR TITLE
Fixes re-layouting from dynamically inserted masonry-bricks.

### DIFF
--- a/src/angular-masonry.js
+++ b/src/angular-masonry.js
@@ -150,7 +150,8 @@
             });
 
             scope.$on('masonry.reload', function () {
-              ctrl.reload();
+              ctrl.scheduleMasonryOnce('reloadItems');
+              ctrl.scheduleMasonryOnce('layout');
             });
 
             scope.$watch('$index', function () {


### PR DESCRIPTION
The change means that the whole grid is actually laid out again when the masonry.reload message is received. It did not work for me before when mixing "static" bricks and some that were loaded by a directive inside a brick. By using the scheduleMasonryOnce function we also assure that we don't get multiple calls. 

If you don't like this, I think it would be a good idea to listen for a seperate message, so that it's possible for dynamically inserted bricks to ask for a new layout the same way that I am doing masonry.reload now.
