### PR TITLE
Update order of package dependencies

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -16,11 +16,11 @@
     "package.json"
   ],
   "dependencies": {
-    "masonry": "~3.2.0",
-    "angular": "~1.3.0",
     "jquery": "~2.1.0",
+    "jquery-bridget": "~1.1.0",
     "imagesloaded": "~3.1.0",
-    "jquery-bridget": "~1.1.0"
+    "masonry": "~3.2.0",
+    "angular": "~1.3.0"
   },
   "devDependencies": {
     "angular-mocks": "~1.3.0",


### PR DESCRIPTION
The previous order of the dependencies seemed to not get along with `wiredep` when using it to automatically inject dependencies in a project.

`jquery-bridget` was being loaded after `masonry` causing the following error:

```
TypeError: element.masonry is not a function
```