### PR TITLE
Add main file to support import via browserify

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "angular-masonry",
   "version": "0.11.0",
+  "main": "angular-masonry.js",
   "devDependencies": {
     "grunt": "~0.4.1",
     "grunt-contrib-concat": "^0.5.1",


### PR DESCRIPTION
Hi!
In order for the project to be picked up by require in browserify, you need to add the `main` file to the `package.json`.
I took the liberty to add it.
Let me know what you think about it!