### PR TITLE
Get minified version when installing via bower

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -9,7 +9,6 @@
     "bower_components",
     "test",
     "src",
-    "*.min.js",
     "*.conf.js",
     "*.html",
     "Gruntfile.js",


### PR DESCRIPTION
Hello,
The current bower.json ignores the minified version.