### PR TITLE
⬆️  update masonry v4, imagesloaded v4, jquery-bridget v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,45 +11,19 @@ An [AngularJS](http://angularjs.org/) directive to work with David Desandro's [M
     2. `npm install --save angular-masonry`
 2. Add `wu.masonry` to your application's module dependencies.
 3. Include dependencies in your HTML.
-    1. When using bower:
-        
-        ```html
-        <script src="bower_components/jquery/dist/jquery.js"></script>
-	    <script src="bower_components/jquery-bridget/jquery.bridget.js"></script>
-	    <script src="bower_components/get-style-property/get-style-property.js"></script>
-	    <script src="bower_components/get-size/get-size.js"></script>
-	    <script src="bower_components/eventEmitter/EventEmitter.js"></script>
-	    <script src="bower_components/eventie/eventie.js"></script>
-	    <script src="bower_components/doc-ready/doc-ready.js"></script>
-	    <script src="bower_components/matches-selector/matches-selector.js"></script>
-	    <script src="bower_components/fizzy-ui-utils/utils.js"></script>
-	    <script src="bower_components/outlayer/item.js"></script>
-	    <script src="bower_components/outlayer/outlayer.js"></script>
-	    <script src="bower_components/masonry/masonry.js"></script>
-	    <script src="bower_components/imagesloaded/imagesloaded.js"></script>
-	    <script src="bower_components/angular/angular.js"></script>
-	    <script src="bower_components/angular-masonry/angular-masonry.js"></script>
-        ```
-    
-    2. When using npm:
-        
-        ```html
-        <script src="node_modules/jquery/dist/jquery.js"></script>
-        <script src="node_modules/jquery-bridget/jquery.bridget.js"></script>
-        <script src="node_modules/desandro-get-style-property/get-style-property.js"></script>
-        <script src="node_modules/get-size/get-size.js"></script>
-        <script src="node_modules/wolfy87-eventemitter/EventEmitter.js"></script>
-        <script src="node_modules/eventie/eventie.js"></script>
-        <script src="node_modules/doc-ready/doc-ready.js"></script>
-        <script src="node_modules/desandro-matches-selector/matches-selector.js"></script>
-        <script src="node_modules/fizzy-ui-utils/utils.js"></script>
-        <script src="node_modules/outlayer/item.js"></script>
-        <script src="node_modules/outlayer/outlayer.js"></script>
-        <script src="node_modules/masonry-layout/masonry.js"></script>
-        <script src="node_modules/imagesloaded/imagesloaded.js"></script>
-        <script src="node_modules/angular/angular.js"></script>
-        <script src="node_modules/angular-masonry/angular-masonry.js"></script>
-        ```
+      ```html
+      <script src="bower_components/jquery/dist/jquery.js"></script>
+      <script src="bower_components/jquery-bridget/jquery-bridget.js"></script>
+      <script src="bower_components/ev-emitter/ev-emitter.js"></script>
+      <script src="bower_components/desandro-matches-selector/matches-selector.js"></script>
+      <script src="bower_components/fizzy-ui-utils/utils.js"></script>
+      <script src="bower_components/outlayer/item.js"></script>
+      <script src="bower_components/outlayer/outlayer.js"></script>
+      <script src="bower_components/masonry/masonry.js"></script>
+      <script src="bower_components/imagesloaded/imagesloaded.js"></script>
+      <script src="bower_components/angular/angular.js"></script>
+      <script src="bower_components/angular-masonry/angular-masonry.js"></script>
+      ```
     
 4. Use the `masonry` directive.
 

--- a/bower.json
+++ b/bower.json
@@ -16,11 +16,11 @@
     "package.json"
   ],
   "dependencies": {
-    "masonry": "~3.3.0",
+    "masonry": "~4.0.0",
     "angular": "^1.3.0",
     "jquery": "~2.1.0",
-    "imagesloaded": "~3.1.0",
-    "jquery-bridget": "~1.1.0"
+    "imagesloaded": "~4.1.0",
+    "jquery-bridget": "~2.0.0"
   },
   "devDependencies": {
     "angular-mocks": "^1.3.0",

--- a/index.html
+++ b/index.html
@@ -79,12 +79,9 @@
 
         <a href="https://github.com/passy/angular-masonry"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_orange_ff7600.png" alt="Fork me on GitHub"></a>
         <script src="bower_components/jquery/dist/jquery.js"></script>
-        <script src="bower_components/jquery-bridget/jquery.bridget.js"></script>
-        <script src="bower_components/get-style-property/get-style-property.js"></script>
+        <script src="bower_components/jquery-bridget/jquery-bridget.js"></script>
         <script src="bower_components/get-size/get-size.js"></script>
-        <script src="bower_components/eventEmitter/EventEmitter.js"></script>
-        <script src="bower_components/eventie/eventie.js"></script>
-        <script src="bower_components/doc-ready/doc-ready.js"></script>
+        <script src="bower_components/ev-emitter/ev-emitter.js"></script>
         <script src="bower_components/matches-selector/matches-selector.js"></script>
         <script src="bower_components/outlayer/item.js"></script>
         <script src="bower_components/outlayer/outlayer.js"></script>

--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
   },
   "dependencies": {
     "angular": "^1.4.1",
-    "imagesloaded": "^3.1.8",
-    "jquery-bridget": "^1.1.0",
-    "masonry-layout": "^3.3.0"
+    "imagesloaded": "^4.1.0",
+    "jquery-bridget": "^2.0.0",
+    "masonry-layout": "^4.0.0"
   }
 }


### PR DESCRIPTION
Masonry v4 is out. I recommend upgrading :grin: 

+ IE8 & 9 support dropped. IE8 dependencies removed: doc-ready, eventie, get-style-property
+ v3 compatible
+ 25% less code

Read over [upgrading from Masonry v3](http://masonry.desandro.com/extras.html#upgrading-from-v3)

This PR updates Masonry, imagesLoaded, and jquery-bridget, and their dependencies to their most recent, post-IE9 versions.