### PR TITLE
update AngularJS to 1.5

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -17,13 +17,13 @@
   ],
   "dependencies": {
     "masonry": "~4.0.0",
-    "angular": "^1.3.0",
+    "angular": "^1.5.0",
     "jquery": "~2.1.0",
     "imagesloaded": "~4.1.0",
     "jquery-bridget": "~2.0.0"
   },
   "devDependencies": {
-    "angular-mocks": "^1.3.0",
+    "angular-mocks": "^1.5.0",
     "sinonjs": "~1.10.0",
     "jasmine-sinon": "~0.4.0"
   }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "angular": "^1.4.1",
+    "angular": "^1.5.0",
     "imagesloaded": "^4.1.0",
     "jquery-bridget": "^2.0.0",
     "masonry-layout": "^4.0.0"

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "karma-jasmine": "^0.3.5",
     "karma-phantomjs-launcher": "^0.2.1",
     "load-grunt-tasks": "^3.1.0",
-    "phantomjs": "^1.9.17"
+    "phantomjs": "^2.1.3"
   },
   "repository": "https://github.com/passy/angular-masonry.git",
   "license": "MIT",


### PR DESCRIPTION
Works well with AngularJS 1.5. Currently using it in two projects with the latest of angular-masonry (v0.15.0) and latest AngularJS. 

I’ve updated the Bower file and package.json. Along with that, the version of PhantomJS is updated. Without bumping to 2.1 you’ll see the following error from Karma when running the unit tests:

`TypeError: 'undefined' is not an object (evaluating 'Function.prototype.bind.apply’)`

That error was discussed/fixed in [issue 56 of karma-phantomjs-launcher](https://github.com/karma-runner/karma-phantomjs-launcher/issues/56).