### PR TITLE
add karma as dependency for npm@3 compatibility 

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -17,13 +17,13 @@
   ],
   "dependencies": {
     "masonry": "~4.0.0",
-    "angular": "^1.3.0",
+    "angular": "^1.5.0",
     "jquery": "~2.1.0",
     "imagesloaded": "~4.1.0",
     "jquery-bridget": "~2.0.0"
   },
   "devDependencies": {
-    "angular-mocks": "^1.3.0",
+    "angular-mocks": "^1.5.0",
     "sinonjs": "~1.10.0",
     "jasmine-sinon": "~0.4.0"
   }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "angular": "^1.4.1",
+    "angular": "^1.5.0",
     "imagesloaded": "^4.1.0",
     "jquery-bridget": "^2.0.0",
     "masonry-layout": "^4.0.0"

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "grunt-karma": "^0.12.0",
     "grunt-ngmin": "0.0.3",
     "jasmine-core": "^2.2.0",
+    "karma": "^0.13.21",
     "karma-coffee-preprocessor": "^0.3.0",
     "karma-jasmine": "^0.3.5",
     "karma-phantomjs-launcher": "^0.2.1",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "karma-jasmine": "^0.3.5",
     "karma-phantomjs-launcher": "^0.2.1",
     "load-grunt-tasks": "^3.1.0",
-    "phantomjs": "^1.9.17"
+    "phantomjs": "^2.1.3"
   },
   "repository": "https://github.com/passy/angular-masonry.git",
   "license": "MIT",


### PR DESCRIPTION
With npm@3, peer dependencies are no longer installed by default. 

> We won’t be automatically downloading the peer dependency anymore. Instead, we’ll warn you if the peer dependency isn’t already installed. 
http://blog.npmjs.org/post/110924823920/npm-weekly-5

This change, then, adds karma as a dependency so it'll install when running `npm install`. Otherwise you'll see:

    npm WARN grunt-karma@0.12.1 requires a peer of karma@^0.13.0 || >= 0.14.0-rc.0 but none was installed.