### PR TITLE
add karma as a dependency for npm@3

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "grunt-karma": "^0.12.0",
     "grunt-ngmin": "0.0.3",
     "jasmine-core": "^2.2.0",
+    "karma": "^0.13.21",
     "karma-coffee-preprocessor": "^0.3.0",
     "karma-jasmine": "^0.3.5",
     "karma-phantomjs-launcher": "^0.2.1",


### PR DESCRIPTION
With npm@3, peer dependencies are no longer installed by default. 

> We won’t be automatically downloading the peer dependency anymore. Instead, we’ll warn you if the peer dependency isn’t already installed. 
http://blog.npmjs.org/post/110924823920/npm-weekly-5

This change, then, adds karma as a dependency so it'll install when running `npm install`. Otherwise you'll see:

    npm WARN grunt-karma@0.12.1 requires a peer of karma@^0.13.0 || >= 0.14.0-rc.0 but none was installed.