### PR TITLE
replace ngmin with ngAnnotate

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -79,10 +79,6 @@ module.exports = function (grunt) {
         src: 'CHANGELOG.md'
       }
     },
-    ngmin: {
-      dist: {
-        src: '<%= pkg.name %>.js',
-        dest: '<%= pkg.name %>.js'
       }
     }
   });

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -79,10 +79,21 @@ module.exports = function (grunt) {
         src: 'CHANGELOG.md'
       }
     },
+    ngAnnotate: {
+      app: {
+        options: {
+          singleQuotes: true,
+        },
+        files: [
+          {
+            '<%= pkg.name %>.js': ['<%= pkg.name %>.js']
+          }
+        ]
       }
     }
   });
 
+  grunt.registerTask('default', ['concat', 'ngAnnotate', 'uglify']);
   grunt.registerTask('server', ['default', 'connect:livereload', 'watch']);
   grunt.registerTask('test', ['karma:dist']);
 };

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -83,7 +83,6 @@ module.exports = function (grunt) {
     }
   });
 
-  grunt.registerTask('default', ['concat', 'ngmin', 'uglify']);
   grunt.registerTask('server', ['default', 'connect:livereload', 'watch']);
   grunt.registerTask('test', ['karma:dist']);
 };

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "grunt-contrib-watch": "^0.6.1",
     "grunt-conventional-changelog": "^5.0.0",
     "grunt-karma": "^0.12.0",
-    "grunt-ngmin": "0.0.3",
+    "grunt-ng-annotate": "^1.0.1",
     "jasmine-core": "^2.2.0",
     "karma": "^0.13.21",
     "karma-coffee-preprocessor": "^0.3.0",


### PR DESCRIPTION
This is to quiet the following warning for [ngmin](https://github.com/btford/ngmin) on npm install: 

`npm WARN deprecated grunt-ngmin@0.0.3: use grunt-ng-annotate instead`