### PR TITLE
docs: add getSize to dependencies code snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ An [AngularJS 1](https://angularjs.org/) directive to work with David Desandro's
       <script src="bower_components/ev-emitter/ev-emitter.js"></script>
       <script src="bower_components/desandro-matches-selector/matches-selector.js"></script>
       <script src="bower_components/fizzy-ui-utils/utils.js"></script>
+      <script src="bower_components/get-size/get-size.js"></script>
       <script src="bower_components/outlayer/item.js"></script>
       <script src="bower_components/outlayer/outlayer.js"></script>
       <script src="bower_components/masonry/masonry.js"></script>


### PR DESCRIPTION
I tried setting up angular-masonry but noticed an extra dependency not met in the readme's code snippet. Maybe this is due to a newer version of Masonry.