### PR TITLE
fix(directive): check for existing elements before appending

### DIFF
--- a/src/angular-masonry.js
+++ b/src/angular-masonry.js
@@ -65,7 +65,10 @@
             // Keep track of added elements.
             bricks[id] = true;
             defaultLoaded(element);
-            $element.masonry(method, element, true);
+            // Don't add element to Masonry if it already has it.
+            if ($element.masonry('getItemElements').indexOf(element.get(0)) === -1) {
+              $element.masonry(method, element, true);
+            }
           }
         }
 

--- a/test/mocks/masonry.mock.js
+++ b/test/mocks/masonry.mock.js
@@ -1,4 +1,5 @@
 (function () {
   'use strict';
-  $.fn.masonry = sinon.spy();
+  $.fn.masonry = sinon.stub();
+  $.fn.masonry.withArgs('getItemElements').returns([]);
 }());

--- a/test/spec/directive.coffee
+++ b/test/spec/directive.coffee
@@ -177,8 +177,10 @@ describe 'angular-masonry', ->
       '''
       element = $compile(element)(@scope)
       @scope.$digest()
-      # 2 is resize and one layout, 3 for the elements
-      expect($.fn.masonry.callCount).toBe(2 + 3)
+      # 2 is resize and one layout
+      # 3 is for checking whether the element is already added
+      # 3 is for appending the elements
+      expect($.fn.masonry.callCount).toBe(2 + 3 + 3)
     )
 
     it 'should prepend elements when specified by attribute', inject(($compile) =>
@@ -247,4 +249,16 @@ describe 'angular-masonry', ->
       @scope.$digest()
       $timeout.flush()
       expect($.fn.masonry.calledWith('layout', sinon.match.any, sinon.match.any)).toBe(true)
+    )
+
+    it 'should not append if masonry already has the element', inject(($compile) =>
+      element = angular.element '''
+        <masonry load-images="false">
+          <div class="masonry-brick"></div>
+        </masonry>
+      '''
+      $.fn.masonry.withArgs('getItemElements').returns indexOf: -> 0
+      element = $compile(element)(@scope)
+      @scope.$digest()
+      expect($.fn.masonry.calledWith('appended', sinon.match.any, sinon.match.any)).toBe(false)
     )


### PR DESCRIPTION
Don't append elements that Masonry has already added to its items.

This fixes the situation in which a static element has already been added to Masonry, but then the `masonry` directive attempts to add a new `masonry-brick` into Masonry's item list.