### PR TITLE
Minor code fixes and refactoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 bower_components/
 *.log
 node_modules/
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 bower_components/
 *.log
 node_modules/
-.idea

--- a/README.md
+++ b/README.md
@@ -12,8 +12,6 @@ An [AngularJS 1](https://angularjs.org/) directive to work with David Desandro's
 2. Add `wu.masonry` to your application's module dependencies.
 3. Include dependencies in your HTML.
       ```html
-      <script src="bower_components/jquery/dist/jquery.js"></script>
-      <script src="bower_components/jquery-bridget/jquery-bridget.js"></script>
       <script src="bower_components/ev-emitter/ev-emitter.js"></script>
       <script src="bower_components/desandro-matches-selector/matches-selector.js"></script>
       <script src="bower_components/fizzy-ui-utils/utils.js"></script>
@@ -21,7 +19,11 @@ An [AngularJS 1](https://angularjs.org/) directive to work with David Desandro's
       <script src="bower_components/outlayer/item.js"></script>
       <script src="bower_components/outlayer/outlayer.js"></script>
       <script src="bower_components/masonry/masonry.js"></script>
+   
+      <!-- optional -->
       <script src="bower_components/imagesloaded/imagesloaded.js"></script>
+      <!-- /optional -->
+   
       <script src="bower_components/angular/angular.js"></script>
       <script src="bower_components/angular-masonry/angular-masonry.js"></script>
       ```
@@ -33,7 +35,7 @@ An [AngularJS 1](https://angularjs.org/) directive to work with David Desandro's
 See the [homepage](http://passy.github.io/angular-masonry) for a live example.
 
 ```html
-<div masonry>
+<div masonry load-images="true">
     <div class="masonry-brick" ng-repeat="brick in bricks">
         <img ng-src="{{ brick.src }}" alt="A masonry brick">
     </div>
@@ -44,8 +46,8 @@ You have to include the `masonry` attribute on the element holding the bricks.
 The bricks are registered at the directive through the `masonry-brick` CSS
 classname.
 
-The directive uses [`imagesloaded`](https://github.com/desandro/imagesloaded) to
-determine when all images within the `masonry-brick` have been loaded and adds
+The directive optionally uses [`imagesloaded`](https://github.com/desandro/imagesloaded)
+to determine when all images within the `masonry-brick` have been loaded and adds
 the `loaded` CSS class to the element, so you can add custom styles and
 prevent ghosting effects.
 
@@ -102,16 +104,14 @@ elements isn't set at the time they are inserted.
 
 ### `load-images`
 
-This attribute defaults to `true` and allows to disable the use of `imagesLoaded`
-altogether, so you don't have to include the dependency if your masonry layout
-doesn't actually make use of images.
+Allows usage of `imagesLoaded` plugin. Defaults to `false`.
 
 *Example:*
 
 ```html
-<masonry load-images="false">
-    <div class="masonry-brick"><p>Only text.</p></div>
-    <div class="masonry-brick"><p>And nothing but text.</p></div>
+<masonry load-images="true">
+    <div class="masonry-brick"><img src="/your/image_1.jpg" alt="image"/></div>
+    <div class="masonry-brick"><img src="/your/image_2.jpg" alt="image"/></div>
 </masonry>
 ```
 

--- a/index.html
+++ b/index.html
@@ -62,14 +62,14 @@
                     <button class="btn btn-primary" ng-click="add()">Add</button>
                     <button class="btn btn-danger" ng-click="remove()">Remove</button>
                 </div>
-                <div masonry>
+                <div masonry load-images="true">
                     <div class="masonry-brick" ng-repeat="brick in bricks">
                         <img ng-src="{{ brick.src }}" alt="A masonry brick">
                     </div>
                 </div>
 
                 <h2>Code</h2>
-                <pre ng-non-bindable>&lt;div <strong>masonry</strong>&gt;
+                <pre ng-non-bindable>&lt;div <strong>masonry load-images="true"</strong>&gt;
     &lt;div <strong>class="masonry-brick"</strong> ng-repeat="brick in bricks"&gt;
         &lt;img ng-src="{{ brick.src }}" alt="A masonry brick"&gt;
     &lt;/div&gt;
@@ -78,8 +78,6 @@
         </div>
 
         <a href="https://github.com/passy/angular-masonry"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_orange_ff7600.png" alt="Fork me on GitHub"></a>
-        <script src="bower_components/jquery/dist/jquery.js"></script>
-        <script src="bower_components/jquery-bridget/jquery-bridget.js"></script>
         <script src="bower_components/get-size/get-size.js"></script>
         <script src="bower_components/ev-emitter/ev-emitter.js"></script>
         <script src="bower_components/matches-selector/matches-selector.js"></script>
@@ -101,7 +99,7 @@
                         return {
                             src: 'http://lorempixel.com/g/280/' + height + '/?' + id
                         };
-                    };
+                    }
 
                     $scope.bricks = [
                         genBrick(),

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -12,8 +12,7 @@ module.exports = function (config) {
       'bower_components/angular/angular.js',
       'bower_components/angular-mocks/angular-mocks.js',
       'src/angular-masonry.js',
-      'test/mocks/**/*.js',
-      'test/spec/**/*.coffee'
+      'test/**/*.coffee'
     ],
     preprocessors: {
       '**/*.coffee': ['coffee']

--- a/src/angular-masonry.js
+++ b/src/angular-masonry.js
@@ -88,9 +88,9 @@
           _layout();
         } else if (self.preserveOrder) {
           _add();
-          element.imagesLoaded(_layout);
+          window.imagesLoaded(element, _layout);
         } else {
-          element.imagesLoaded(function imagesLoaded() {
+          window.imagesLoaded(element, function imagesLoaded() {
             _add();
             _layout();
           });

--- a/test/directive.coffee
+++ b/test/directive.coffee
@@ -8,105 +8,79 @@ describe 'angular-masonry', ->
     null
   )
 
-  beforeEach inject(($rootScope) =>
+  beforeEach inject(($rootScope, $compile) =>
+    @compile = $compile
     @scope = $rootScope.$new()
   )
 
   describe 'directive initialization', =>
     beforeEach =>
-      @Masonry = window.Masonry;
-      window.Masonry = sinon.spy();
+      @Masonry = window.Masonry
+      window.Masonry = sinon.spy()
 
     afterEach =>
-      window.Masonry = @Masonry;
+      window.Masonry = @Masonry
 
-    it 'should initialize', inject(($compile) =>
-      element = angular.element '<masonry></masonry>'
-      element = $compile(element)(@scope)
-    )
+    it 'should initialize', =>
+      @compile('<masonry></masonry>')(@scope)
 
-    it 'should call masonry on init', inject(($compile) =>
-      element = angular.element '<div masonry></div>'
-      element = $compile(element)(@scope)
-
+    it 'should call masonry on init', =>
+      @compile('<div masonry></div>')(@scope)
       expect(window.Masonry).toHaveBeenCalled()
-    )
 
-    it 'should pass on the column-width attribute', inject(($compile) =>
-      element = angular.element '<masonry column-width="200"></masonry>'
-      element = $compile(element)(@scope)
-
+    it 'should pass on the column-width attribute', =>
+      @compile('<masonry column-width="200"></masonry>')(@scope)
       expect(window.Masonry).toHaveBeenCalledOnce()
+
       call = window.Masonry.firstCall
       expect(call.args[1].columnWidth).toBe 200
-    )
 
-    it 'should pass on the item-selector attribute', inject(($compile) =>
-      element = angular.element '<masonry item-selector=".mybrick"></masonry>'
-      element = $compile(element)(@scope)
-
+    it 'should pass on the item-selector attribute', =>
+      @compile('<masonry item-selector=".mybrick"></masonry>')(@scope)
       expect(window.Masonry).toHaveBeenCalled()
+
       call = window.Masonry.firstCall
       expect(call.args[1].itemSelector).toBe '.mybrick'
-    )
 
-    it 'should pass on any options provided via `masonry-options`', inject(($compile) =>
-      element = angular.element '<masonry masonry-options="{ isOriginLeft: true }"></masonry>'
-      element = $compile(element)(@scope)
-
+    it 'should pass on any options provided via `masonry-options`', =>
+      @compile('<masonry masonry-options="{ isOriginLeft: true }"></masonry>')(@scope)
       expect(window.Masonry).toHaveBeenCalled()
+
       call = window.Masonry.firstCall
       expect(call.args[1].isOriginLeft).toBeTruthy()
-    )
 
-    it 'should pass on any options provided via `masonry`', inject(($compile) =>
-      element = angular.element '<div masonry="{ isOriginLeft: true }"></div>'
-      element = $compile(element)(@scope)
-
+    it 'should pass on any options provided via `masonry`', =>
+      @compile('<div masonry="{ isOriginLeft: true }"></div>')(@scope)
       expect(window.Masonry).toHaveBeenCalled()
+
       call = window.Masonry.firstCall
       expect(call.args[1].isOriginLeft).toBeTruthy()
-    )
 
   describe 'directive watchers', =>
-    it 'should setup a $watch when the reload-on-show is present', inject(($compile) =>
+    beforeEach =>
       sinon.spy(@scope, '$watch')
-      element = angular.element '<masonry reload-on-show></masonry>'
-      element = $compile(element)(@scope)
 
+    it 'should setup a $watch when the reload-on-show is present', =>
+      @compile('<masonry reload-on-show></masonry>')(@scope)
       expect(@scope.$watch).toHaveBeenCalled()
-    )
 
-    it 'should not setup a $watch when the reload-on-show is missing', inject(($compile) =>
-      sinon.spy(@scope, '$watch')
-      element = angular.element '<masonry></masonry>'
-      element = $compile(element)(@scope)
-
+    it 'should not setup a $watch when the reload-on-show is missing', =>
+      @compile('<masonry></masonry>')(@scope)
       expect(@scope.$watch).not.toHaveBeenCalled()
-    )
 
-    it 'should setup a $watch when the reload-on-resize is present', inject(($compile) =>
-      sinon.spy(@scope, '$watch')
-      element = angular.element '<masonry reload-on-resize></masonry>'
-      element = $compile(element)(@scope)
+    it 'should setup a $watch when the reload-on-resize is present', =>
+      @compile('<masonry reload-on-resize></masonry>')(@scope)
+      expect(@scope.$watch).toHaveBeenCalledWith('masonryContainer.offsetWidth', sinon.match.func);
 
-      expect(@scope.$watch).toHaveBeenCalledWith('masonryContainer.offsetWidth', sinon.match.func );
-    )
-
-    it 'should not setup a $watch when the reload-on-resize is missing', inject(($compile) =>
-      sinon.spy(@scope, '$watch')
-      element = angular.element '<masonry></masonry>'
-      element = $compile(element)(@scope)
-
-      expect(@scope.$watch).not.toHaveBeenCalledWith('masonryContainer.offsetWidth', sinon.match.func );
-    )
+    it 'should not setup a $watch when the reload-on-resize is missing', =>
+      @compile('<masonry></masonry>')(@scope)
+      expect(@scope.$watch).not.toHaveBeenCalledWith('masonryContainer.offsetWidth', sinon.match.func);
 
   describe 'MasonryCtrl', =>
-    beforeEach inject(($compile) =>
-      $compile('<masonry></masonry>')(@scope)
+    beforeEach =>
+      @compile('<masonry></masonry>')(@scope)
       @ctrl = @scope.msnry
       @ctrl.destroy()
-    )
 
     it 'should not remove after destruction', =>
       @ctrl.remove = sinon.spy();
@@ -131,25 +105,24 @@ describe 'angular-masonry', ->
         this
       )
 
-    it 'should register an element in the parent controller', inject(($compile) =>
-      element = angular.element '''
+    it 'should register an element in the parent controller', =>
+      @compile('''
         <masonry>
           <div class="masonry-brick"></div>
         </masonry>
-      '''
-      element = $compile(element)(@scope)
+      ''')(@scope)
 
       expect(@scope.msnry.addBrick).toHaveBeenCalledOnce()
-    )
 
-    it 'should remove an element in the parent controller if destroyed', inject(($compile) =>
+    it 'should remove an element in the parent controller if destroyed', =>
       @scope.bricks = [1, 2, 3]
-      element = angular.element '''
+
+      @compile('''
         <masonry>
           <div class="masonry-brick" ng-repeat="brick in bricks"></div>
         </masonry>
-      '''
-      element = $compile(element)(@scope)
+      ''')(@scope)
+
       @scope.$digest() # Needed for initial ng-repeat
 
       @scope.$apply(=>
@@ -158,7 +131,6 @@ describe 'angular-masonry', ->
 
       expect(@scope.msnry.addBrick).toHaveBeenCalledThrice()
       expect(@scope.msnry.removeBrick).toHaveBeenCalledOnce()
-    )
 
   describe 'MasonryCtrl.addBrick', =>
     beforeEach ->
@@ -167,56 +139,49 @@ describe 'angular-masonry', ->
         this
       )
 
-    it 'should append three elements to the controller', inject(($compile) =>
-      element = angular.element '''
+    it 'should append three elements to the controller', =>
+      @compile('''
         <masonry>
           <div class="masonry-brick"></div>
           <div class="masonry-brick"></div>
           <div class="masonry-brick"></div>
         </masonry>
-      '''
-      element = $compile(element)(@scope)
+      ''')(@scope)
 
       expect(@scope.msnry.addBrick.callCount).toBe 3
-    )
 
-    it 'should prepend elements when specified by attribute', inject(($compile) =>
-      element = angular.element '''
+    it 'should prepend elements when specified by attribute', =>
+      @compile('''
         <masonry>
           <div class="masonry-brick" prepend="{{true}}"></div>
         </masonry>
-      '''
-      element = $compile(element)(@scope)
+      ''')(@scope)
 
       expect(@scope.msnry.addBrick).toHaveBeenCalledWith 'prepended'
-    )
 
-    it 'should append before imagesLoaded when preserve-order is set', inject(($compile) =>
-      element = angular.element '''
+    it 'should append before imagesLoaded when preserve-order is set', =>
+      @compile('''
         <masonry load-images="true" preserve-order>
           <div class="masonry-brick"></div>
         </masonry>
-      '''
-      element = $compile(element)(@scope)
+      ''')(@scope)
 
       expect(@scope.msnry.addBrick).toHaveBeenCalledWith 'appended'
-    )
 
   describe 'MasonryCtrl.scheduleMasonryOnce', =>
     beforeEach =>
       @imagesLoadedCb = undefined
-      $.fn.imagesLoaded = (cb) => @imagesLoadedCb = cb
+      window.imagesLoaded = (el, cb) => @imagesLoadedCb = cb
 
-    it 'should call layout after imagesLoaded when preserve-order is set', inject(($compile, $timeout) =>
+    it 'should call layout after imagesLoaded when preserve-order is set', inject(($timeout) =>
       @layout = window.Masonry.prototype.layout
       @spy = sinon.spy(window.Masonry.prototype, 'layout')
 
-      element = angular.element '''
+      @compile('''
         <masonry load-images="true" preserve-order>
           <div class="masonry-brick"></div>
         </masonry>
-      '''
-      $compile(element)(@scope)
+      ''')(@scope)
 
       @scope.$digest()
       expect(@spy).toHaveBeenCalledOnce()
@@ -227,26 +192,24 @@ describe 'angular-masonry', ->
       window.Masonry.prototype.layout = @layout
     )
 
-    it 'should append before imagesLoaded when load-images is set to "false"', inject(($compile) =>
+    it 'should append before imagesLoaded when load-images is set to "false"', =>
       @appended = window.Masonry.prototype.appended
       @spy = sinon.spy(window.Masonry.prototype, 'appended')
 
-      element = angular.element '''
+      @compile('''
         <masonry>
           <div class="masonry-brick"></div>
         </masonry>
-      '''
-      $compile(element)(@scope)
+      ''')(@scope)
 
       expect(@spy).toHaveBeenCalledOnce()
       window.Masonry.prototype.appended = @appended
-    )
 
-    it 'should call layout before imagesLoaded when load-images is set to "false"', inject(($compile, $timeout) =>
+    it 'should call layout before imagesLoaded when load-images is set to "false"', inject(($timeout) =>
       @layout = window.Masonry.prototype.layout
       @spy = sinon.spy(window.Masonry.prototype, 'layout');
 
-      $compile('''
+      @compile('''
         <masonry load-images="false">
           <div class="masonry-brick"></div>
         </masonry>

--- a/test/mocks/masonry.mock.js
+++ b/test/mocks/masonry.mock.js
@@ -1,4 +1,0 @@
-(function () {
-  'use strict';
-  $.fn.masonry = sinon.spy();
-}());


### PR DESCRIPTION
Refactoring tests - removing unnecessary injects, variables and mocks.
Refactoring `imagesLoaded` call to use window function instead of jQuery one.
Reflecting recent code changes in docs.

**NB:** Please make a new release (build artifacts) with a note "breaking changes" - the `imagesLoaded` behavior was changed to a completely opposite, see PR #183 